### PR TITLE
WebWorker Compatibility

### DIFF
--- a/src/js/userAgent.js
+++ b/src/js/userAgent.js
@@ -150,5 +150,11 @@
         window.daumtools = (typeof window.daumtools === 'undefined') ? {} : window.daumtools;
         window.util = (typeof window.util === 'undefined') ? window.daumtools : window.util;
         return window.daumtools;
+    } else if (typeof self === 'object') {
+        // for use in web workers
+        self.daumtools = (typeof self.daumtools === 'undefined') ? {} : self.daumtools;
+        self.util = (typeof self.util === 'undefined') ? self.daumtools : self.util;
+        return self;
     }
+
 })());

--- a/src/js/userAgent.js
+++ b/src/js/userAgent.js
@@ -156,5 +156,4 @@
         self.util = (typeof self.util === 'undefined') ? self.daumtools : self.util;
         return self;
     }
-
 })());


### PR DESCRIPTION
I'd like to use this inside of a web worker where neither `exports` nor `window` exists. For workers, you can use `self` as the global namespace.
