### PR TITLE
Address undefined window case for isTablet()

### DIFF
--- a/src/js/ua_parser.js
+++ b/src/js/ua_parser.js
@@ -72,7 +72,7 @@
     }
     function isTablet (ua) {
         if (ua.match(/ipad/) || (ua.match(/android/) && !ua.match(/mobi|mini|fennec/)) || 
-        (ua.match(/macintosh/) && window.navigator.maxTouchPoints > 1)) {
+        (ua.match(/macintosh/) && typeof window !== 'undefined' && window.navigator && window.navigator.maxTouchPoints > 1)) {
             return true;
         }
         return false;
@@ -109,7 +109,7 @@
             match[2] = "0.98.0";
         }
 
-        if (match[1] === "mac" && (typeof window !== 'undefined' && window.navigator.maxTouchPoints > 1)) {
+        if (match[1] === "mac" && (typeof window !== 'undefined' && window.navigator && window.navigator.maxTouchPoints > 1)) {
             match[1] = "ios";
         }
         if (match[1] === 'cros') {


### PR DESCRIPTION
## Context

As a follow-up to https://github.com/html5crew/ua_parser/issues/11, we finally bumped our version of ua_parser to `1.2.8` and ran into another undefined window case - this time, it's in isTablet()

## Changes
- Add window-undefined check to `isTablet` and also check for `window-navigator`
- Update `checkOs()` window-related logic to also check `window.navigator` to be more defensive